### PR TITLE
Allow custom Plex restart command

### DIFF
--- a/deploy/plex_synology.sh
+++ b/deploy/plex_synology.sh
@@ -15,6 +15,8 @@
 # PLEX_PKCS12_password -- Password for the PKCS file. Required by plex
 # PLEX_PKCS12_file -- Full PKCS file location, otherwise defaults to placing with the other certs in that domain with a pfx extension
 # PLEX_sudo_required -- 1 = True, 0 = False. You may need to add "plex ALL=(ALL) NOPASSWD:/bin/systemctl restart plexmediaserver.service" to your sudo'ers file
+# PLEX_RELOAD -- Optional custom command to restart Plex. If not set, the script will use
+#                Synology's synopkg restart when Plex is detected as active.
 
 # Set Plex certificate location to /usr/local/share/Plex/plex_cert.pfx
 
@@ -37,6 +39,7 @@ plex_synology_deploy() {
   _getdeployconf PLEX_PKCS12_password
   _getdeployconf PLEX_PKCS12_file
   _getdeployconf PLEX_sudo_required
+  _getdeployconf PLEX_RELOAD
 
   #_DEPLOY_PLEX_WIKI="https://github.com/acmesh-official/acme.sh/wiki/deploy-to-plex"
 
@@ -72,8 +75,9 @@ plex_synology_deploy() {
   fi
 
   _debug2 PLEX_sudo_required "$PLEX_sudo_required"
+  _debug2 PLEX_RELOAD "$PLEX_RELOAD"
 
-  _reload_cmd=""
+  _reload_cmd="$PLEX_RELOAD"
 
   _debug "Generate import pkcs12"
 
@@ -82,9 +86,11 @@ plex_synology_deploy() {
     return 1
   fi
 
-  if systemctl -q is-active pkgctl-PlexMediaServer.service; then
-    _debug2 "Plex is active. Restarting..."
-    _reload_cmd="/usr/syno/bin/synopkg restart PlexMediaServer"
+  if [ -z "$_reload_cmd" ]; then
+    if systemctl -q is-active pkgctl-PlexMediaServer.service; then
+      _debug2 "Plex is active. Restarting..."
+      _reload_cmd="/usr/syno/bin/synopkg restart PlexMediaServer"
+    fi
   fi
   if [ -z "$_reload_cmd" ]; then
     _info "Plex server is not active. Certificates installed, but skipping restart."
@@ -104,6 +110,7 @@ plex_synology_deploy() {
   _savedeployconf PLEX_PKCS12_password "$PLEX_PKCS12_password"
   _savedeployconf PLEX_PKCS12_file "$PLEX_PKCS12_file"
   _savedeployconf PLEX_sudo_required "$PLEX_sudo_required"
+  _savedeployconf PLEX_RELOAD "$PLEX_RELOAD"
 
   return 0
 }


### PR DESCRIPTION
## Summary
- support `PLEX_RELOAD` environment variable to override the Plex restart command
- persist the value in deployment configuration

## Testing
- `shellcheck -V` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_684849e63a288330aecf3adb5245c7a1